### PR TITLE
user is able to revert changes back to original reminder before saving

### DIFF
--- a/app/components/edit-reminder.js
+++ b/app/components/edit-reminder.js
@@ -8,6 +8,11 @@ export default Ember.Component.extend({
       this.get('store').findRecord('reminder', this.model.id).then(reminder => {
         reminder.save()
       })
+    },
+    rollBackTheRock(){
+      this.get('store').findRecord('reminder', this.model.id).then(reminder =>{
+        reminder.rollbackAttributes()
+      })
     }
   }
 })

--- a/app/controllers/reminders/reminder/add-reminder.js
+++ b/app/controllers/reminders/reminder/add-reminder.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  actions: {
+    addReminder() {
+      console.log('woot there it is');
+    }
+  }
+});

--- a/app/controllers/reminders/reminder/add-reminder.js
+++ b/app/controllers/reminders/reminder/add-reminder.js
@@ -1,9 +1,4 @@
 import Ember from 'ember';
 
 export default Ember.Controller.extend({
-  actions: {
-    addReminder() {
-      console.log('woot there it is');
-    }
-  }
 });

--- a/app/templates/components/edit-reminder.hbs
+++ b/app/templates/components/edit-reminder.hbs
@@ -1,3 +1,5 @@
 {{#link-to 'reminders.reminder'}}
   <button class='save-reminder-btn' {{action 'saveDirtyDiana' on='click'}}>Save</button>
 {{/link-to}}
+
+<button class='undo-btn' {{action 'rollBackTheRock' on='click'}}>Undo</button>

--- a/app/templates/reminders/reminder/edit-reminder.hbs
+++ b/app/templates/reminders/reminder/edit-reminder.hbs
@@ -1,6 +1,7 @@
 <p> remember to save your changes! </p>
-<h3 class='edit-title'>{{input value=model.title}}</h3>
-<p class='edit-date'>{{input value=model.date}}</p>
-<p class='edit-notes'>{{input value=model.notes}}</p>
-
+<div class='edited-reminder'>
+  <h3 class='edit-title'>{{input value=model.title}}</h3>
+  <p class='edit-date'>{{input value=model.date}}</p>
+  <p class='edit-notes'>{{input value=model.notes}}</p>
+</div>
 {{edit-reminder model=model}}

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -2,7 +2,6 @@
 
 import { test } from 'qunit';
 import moduleForAcceptance from 'remember/tests/helpers/module-for-acceptance';
-
 import Ember from 'ember';
 
 moduleForAcceptance('Acceptance | reminders list');
@@ -144,6 +143,10 @@ test('user should be able to edit the reminder', function(assert) {
     assert.equal(find('.edit-notes input').val(), 'Has got it going on, too', 'notes value is correct');
   })
 
+  andThen(function(){
+    assert.equal(find('.edited-reminder').hasDirtyAttributes)
+  })
+  
   click('.save-reminder-btn');
 
   andThen(function(){
@@ -169,6 +172,10 @@ test('user should be able to revert an unsaved edit', function(assert){
   fillIn('.edit-title input', 'What did the ocean say to the penguin');
   fillIn('.edit-date input', '???');
   fillIn('.edit-notes input', 'Nothing, it just waved');
+
+  andThen(function(){
+    assert.equal(find('.edited-reminder').hasDirtyAttributes)
+  })
 
   andThen(function(){
     assert.equal(find('.edit-title input').val(), 'What did the ocean say to the penguin', 'title value is correct');

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -156,3 +156,31 @@ test('user should be able to edit the reminder', function(assert) {
     assert.equal(find('.spec-reminder-notes').text().trim(), 'Has got it going on, too', 'should show new notes');
   })
 })
+
+test('user should be able to revert an unsaved edit', function(assert){
+  visit('/reminders/new')
+
+  fillIn('.title-input', 'How do you find Will Smith in the snow')
+  fillIn('.date-input', '???');
+  fillIn('.notes-input', 'You look for the fresh prints')
+  click('.submit-new-btn')
+  click('.spec-reminder-title:first')
+  click('.edit-reminder-btn')
+  fillIn('.edit-title input', 'What did the ocean say to the penguin');
+  fillIn('.edit-date input', '???');
+  fillIn('.edit-notes input', 'Nothing, it just waved');
+
+  andThen(function(){
+    assert.equal(find('.edit-title input').val(), 'What did the ocean say to the penguin', 'title value is correct');
+    assert.equal(find('.edit-date input').val(), '???', 'date value is correct');
+    assert.equal(find('.edit-notes input').val(), 'Nothing, it just waved', 'notes value is correct');
+  })
+
+  click('.undo-btn')
+
+  andThen(function(){
+    assert.equal(find('.edit-title input').val(), 'How do you find Will Smith in the snow', 'title value is reverted');
+    assert.equal(find('.edit-date input').val(), '???', 'date value is reverted');
+    assert.equal(find('.edit-notes input').val(), 'You look for the fresh prints', 'notes value reverted');
+  })
+})


### PR DESCRIPTION
## Purpose
User is able to revert back to the original reminder before saving their changes to the store.
Closes issue #17 

## Approach
We looked up the rollbackAttributes function in the docs.

### Learning

Looking at docs and playing around with actions. 

http://emberjs.com/api/data/classes/DS.Model.html#method_rollbackAttributes


### Test coverage 

wrote a test that is given an original reminder then edits that reminder and instead of saving it, we revert back to the original. 


### Follow-up tasks

https://github.com/turingschool-projects/1610-remember-4/issues/14


### Screenshots
![screen shot 2017-02-14 at 11 16 17 am](https://cloud.githubusercontent.com/assets/19477616/22942556/380cc7c6-f2a7-11e6-92f1-94380928a225.png)